### PR TITLE
feat(sticky-prettier): include prettier-plugin-tailwindcss

### DIFF
--- a/packages/sticky-prettier/index.js
+++ b/packages/sticky-prettier/index.js
@@ -2,4 +2,5 @@ module.exports = {
   printWidth: 120,
   trailingComma: 'all',
   singleQuote: true,
+  plugins: [require('prettier-plugin-tailwindcss')],
 };

--- a/packages/sticky-prettier/package.json
+++ b/packages/sticky-prettier/package.json
@@ -8,6 +8,7 @@
   "dependencies": {
     "husky": "^8.0.1",
     "lint-staged": "^13.0.3",
-    "prettier": "^2.7.1"
+    "prettier": "^2.7.1",
+    "prettier-plugin-tailwindcss": "^0.1.13"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,10 +61,12 @@ importers:
       husky: ^8.0.1
       lint-staged: ^13.0.3
       prettier: ^2.7.1
+      prettier-plugin-tailwindcss: ^0.1.13
     dependencies:
       husky: 8.0.1
       lint-staged: 13.0.3
       prettier: 2.7.1
+      prettier-plugin-tailwindcss: 0.1.13_prettier@2.7.1
 
   packages/sticky-turbo:
     specifiers:
@@ -4063,6 +4065,15 @@ packages:
   /prelude-ls/1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
+    dev: false
+
+  /prettier-plugin-tailwindcss/0.1.13_prettier@2.7.1:
+    resolution: {integrity: sha512-/EKQURUrxLu66CMUg4+1LwGdxnz8of7IDvrSLqEtDqhLH61SAlNNUSr90UTvZaemujgl3OH/VHg+fyGltrNixw==}
+    engines: {node: '>=12.17.0'}
+    peerDependencies:
+      prettier: '>=2.2.0'
+    dependencies:
+      prettier: 2.7.1
     dev: false
 
   /prettier/2.7.1:


### PR DESCRIPTION
#### What this PR does / why we need it:

Include `prettier-plugin-tailwindcss` to prettier as a standardized adoption as it's widely required for most projects, and it won't cause issues with projects that don't require it.