### PR TITLE
fix(sticky-turbo-jest): rely on child process exit code for failure d…

### DIFF
--- a/packages/sticky-turbo-jest/jest-turbo.js
+++ b/packages/sticky-turbo-jest/jest-turbo.js
@@ -30,7 +30,12 @@ async function run(rootDir, script, filter) {
     cwd: rootDir,
   });
 
-  if (spawn.stderr && spawn.stderr.length > 0) {
-    throw new Error(spawn.stderr.toString('utf-8'));
+  // Throw error if non-zero exit code encountered
+  if (spawn.status !== 0) {
+    const failureMessage =
+      spawn.stderr && spawn.stderr.length > 0
+        ? spawn.stderr.toString('utf-8')
+        : `Encountered non-zero exit code while running script: ${script}`;
+    throw new Error(failureMessage);
   }
 }


### PR DESCRIPTION
#### What this PR does / why we need it:
- As per title

#### Which issue(s) does this PR fixes?:
- Sticky downstream projects encountering jest run failures due to turbo warnings like `Skipping cache check for <package>, outputs have not changed since previous run` which are written to stderr

---

#### Breakdown
- [Turbo will write to stderr when it wants to warn the user about something](https://github.com/vercel/turbo/blob/4e1838032ed922bc854d5de56b432b0ce5378136/cli/internal/runcache/runcache.go#L189)
- Hence this "skipping cache check" warning is being written to stderr by turbo and being identified as an error by sticky-turbo

- **[Should I output warnings to STDERR or STDOUT?](https://stackoverflow.com/questions/1430956/should-i-output-warnings-to-stderr-or-stdout)**
  > If I save the output of this script (i.e. stdout only) so that I could process it later, would that warning interfere with how the output is parsed? Moreover, if output is piped to another process, the warning should show up on the terminal, so the user sees it immediately.
  > For those reasons, in general, you output warnings to stderr.

#### Solution
- Rely on the process exit code to identify errors instead of the stderr stream.
