### PR TITLE
fix(sticky-turbo): do not hard code path separator

### DIFF
--- a/packages/sticky-turbo/src/Turbo.ts
+++ b/packages/sticky-turbo/src/Turbo.ts
@@ -1,6 +1,6 @@
 import { spawnSync, SpawnSyncReturns, StdioOptions } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
-import { dirname, join } from 'node:path';
+import { dirname, join, sep } from 'node:path';
 
 import { PackageJson } from './PackageJson';
 
@@ -184,10 +184,10 @@ export class Turbo {
  * @param depth {number} on how far up to search
  */
 export function findRootTurboJsonPath(cwd: string, depth: number = 4): string | undefined {
-  const paths = cwd.split('/');
+  const paths = cwd.split(sep);
 
   for (let i = 0; i < depth; i += 1) {
-    const path = `${paths.join('/')}/turbo.json`;
+    const path = `${paths.join(sep)}/turbo.json`;
     if (existsSync(path)) {
       const object = JSON.parse(readFileSync(path, { encoding: 'utf-8' }));
       if (!object.extends?.includes('//')) {


### PR DESCRIPTION
#### What this PR does / why we need it:

Do not hard code path separator and use `sep from node:path`.

#### Which issue(s) will this PR fix?:

Fixes #93
