### PR TITLE
feat(eslint-config): add eslint-plugin-unused-imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,9 +22,8 @@
     "*": "prettier --write --ignore-unknown"
   },
   "prettier": "@birthdayresearch/sticky-prettier",
-  "packageManager": "pnpm@8.6.1",
   "engines": {
     "node": "^18.0.0",
-    "pnpm": ">=8.6.1"
+    "pnpm": ">=7.13.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,8 +22,9 @@
     "*": "prettier --write --ignore-unknown"
   },
   "prettier": "@birthdayresearch/sticky-prettier",
+  "packageManager": "pnpm@8.6.1",
   "engines": {
     "node": "^18.0.0",
-    "pnpm": ">=7.13.0"
+    "pnpm": ">=8.6.1"
   }
 }

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -1,5 +1,5 @@
 module.exports = {
-  plugins: ['simple-import-sort', 'check-file'],
+  plugins: ['simple-import-sort', 'check-file', 'unused-imports'],
   extends: ['airbnb-base', 'airbnb-typescript/base', 'prettier'],
   ignorePatterns: ['dist'],
   rules: {
@@ -35,6 +35,10 @@ module.exports = {
 
     // @typescript-eslint
     '@typescript-eslint/no-use-before-define': 'off',
+
+    '@typescript-eslint/no-unused-vars': 'off',
+    'unused-imports/no-unused-imports': 'error',
+    'unused-imports/no-unused-vars': 'error',
   },
   env: {
     node: true,
@@ -43,7 +47,12 @@ module.exports = {
   overrides: [
     {
       files: ['**/*.unit.ts', '**/*.i9n.ts', '**/*.e2e.ts'],
-      rules: {},
+      rules: {
+        'no-lone-blocks': 'off',
+
+        'unused-imports/no-unused-imports': 'error',
+        'unused-imports/no-unused-vars': 'off',
+      },
     },
     {
       files: ['src/**/{index,cli,main}.ts'],

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -14,6 +14,7 @@
     "eslint-config-prettier": "^8.8.0",
     "eslint-plugin-check-file": "^2.3.0",
     "eslint-plugin-import": "^2.27.5",
-    "eslint-plugin-simple-import-sort": "^10.0.0"
+    "eslint-plugin-simple-import-sort": "^10.0.0",
+    "eslint-plugin-unused-imports": "^2.0.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       eslint-plugin-simple-import-sort:
         specifier: ^10.0.0
         version: 10.0.0(eslint@8.42.0)
+      eslint-plugin-unused-imports:
+        specifier: ^2.0.0
+        version: 2.0.0(@typescript-eslint/eslint-plugin@5.59.8)(eslint@8.42.0)
 
   packages/sticky-docs:
     devDependencies:
@@ -2288,6 +2291,26 @@ packages:
       eslint: '>=5.0.0'
     dependencies:
       eslint: 8.42.0
+    dev: false
+
+  /eslint-plugin-unused-imports@2.0.0(@typescript-eslint/eslint-plugin@5.59.8)(eslint@8.42.0):
+    resolution: {integrity: sha512-3APeS/tQlTrFa167ThtP0Zm0vctjr4M44HMpeg1P4bK6wItarumq0Ma82xorMKdFsWpphQBlRPzw/pxiVELX1A==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      '@typescript-eslint/eslint-plugin': ^5.0.0
+      eslint: ^8.0.0
+    peerDependenciesMeta:
+      '@typescript-eslint/eslint-plugin':
+        optional: true
+    dependencies:
+      '@typescript-eslint/eslint-plugin': 5.59.8(@typescript-eslint/parser@5.59.8)(eslint@8.42.0)(typescript@4.9.5)
+      eslint: 8.42.0
+      eslint-rule-composer: 0.3.0
+    dev: false
+
+  /eslint-rule-composer@0.3.0:
+    resolution: {integrity: sha512-bt+Sh8CtDmn2OajxvNO+BX7Wn4CIWMpTRm3MaiKPCQcnnlm0CS2mhui6QaoeQugs+3Kj2ESKEEGJUdVafwhiCg==}
+    engines: {node: '>=4.0.0'}
     dev: false
 
   /eslint-scope@5.1.1:


### PR DESCRIPTION
#### What this PR does / why we need it:

Added https://www.npmjs.com/package/eslint-plugin-unused-imports which separates out the `no-unused-vars` rule depending on it being an import statement in the AST and providing an auto-fix rule to remove the nodes if they are imports. With this, we can now target test files with `'unused-imports/no-unused-vars': 'off'` for testing DX.

Breaking changes, to replace:
```diff
- // eslint-disable-next-line @typescript-eslint/no-unused-vars
+ // eslint-disable-next-line unused-imports/no-unused-vars
```
