### PR TITLE
chore(workflows): pnpm publish with --provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
 
       - run: npm config set "//registry.npmjs.org/:_authToken" "\${NPM_AUTH_TOKEN}" --location=project
 
-      - run: pnpm -r publish --access public --tag latest --no-git-checks
+      - run: pnpm -r publish --provenance --access public --tag latest --no-git-checks
         env:
           NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
 


### PR DESCRIPTION
#### What this PR does / why we need it:

Publish sticky with `--provenance`.