### PR TITLE
chore(workflows): use NPM_CONFIG_PROVENANCE=true

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,9 +44,10 @@ jobs:
 
       - run: npm config set "//registry.npmjs.org/:_authToken" "\${NPM_AUTH_TOKEN}" --location=project
 
-      - run: pnpm -r publish --provenance --access public --tag latest --no-git-checks
+      - run: pnpm -r publish --access public --tag latest --no-git-checks
         env:
           NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
+          NPM_CONFIG_PROVENANCE: true
 
       - run: npm config delete "//registry.npmjs.org/:_authToken" --location=project
         if: always()


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:

Instead of `--provenance` use `NPM_CONFIG_PROVENANCE=true` when publishing.
